### PR TITLE
add default select project for create-task-form

### DIFF
--- a/src/components/date-picker.tsx
+++ b/src/components/date-picker.tsx
@@ -38,12 +38,12 @@ export const DatePicker = ({ value, onChange, className, placeholder = "Select d
                 </Button>
             </PopoverTrigger>
             <PopoverContent className="w-auto p-0">
-                <Calendar
-                    mode="single"
-                    selected={value}
-                    onSelect={(date) => onChange(date as Date)}
-                    initialFocus
-                />
+            <Calendar
+                mode="single"
+                selected={value ?? undefined} 
+                onSelect={(date) => onChange(date ?? undefined)}
+                initialFocus
+            />
             </PopoverContent>
         </Popover>
     )

--- a/src/features/tasks/components/create-task-form-wrapper.tsx
+++ b/src/features/tasks/components/create-task-form-wrapper.tsx
@@ -8,10 +8,13 @@ import { CreateTaskForm } from "./create-task-form";
 
 interface CreateTaskFormWrapperProps {
     onCancel: () => void;
+    selectProjetId?: string // NOTE: si le modal est ouvert dans un projet déja selectionner , 
+                            // pas besoin de redemander à l'utilisateur de selectionner le projet !
 }
 
 export const CreateTaskFormWrapper = ({
-    onCancel
+    onCancel,
+    selectProjetId
 }: CreateTaskFormWrapperProps) => {
     const workspaceId = useWorkspaceId()
 
@@ -46,6 +49,7 @@ export const CreateTaskFormWrapper = ({
             onCancel={onCancel}
             projectOptions={projectOptions ?? []}
             memberOptions={memberOptions ?? []}
+            currentProjet={selectProjetId}
         />
     )
 }

--- a/src/features/tasks/components/create-task-form.tsx
+++ b/src/features/tasks/components/create-task-form.tsx
@@ -105,15 +105,17 @@ export const CreateTaskForm = ({
                     <FormLabel>Date d&apos;échéance</FormLabel>
                     <FormControl>
                       <DatePicker
-                        {...field}
-                        value={field.value ? new Date(field.value) : undefined}
-                        onChange={(date) => field.onChange(date || "")}
+                        value={field.value ? new Date(field.value) : undefined} // Convertit une date valide, sinon undefined
+                        onChange={(date) =>
+                          field.onChange(date ? date.toISOString() : "")
+                        } 
                       />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
                 )}
               />
+
               <FormField
                 control={form.control}
                 name="assigneeId"

--- a/src/features/tasks/components/create-task-form.tsx
+++ b/src/features/tasks/components/create-task-form.tsx
@@ -33,10 +33,12 @@ import {
 import { TaskStatus, TaskPriority } from "../types";
 import { createtaskSchema } from "../schemas";
 import { useCreateTask } from "../api/use-create-task";
+import { useEffect } from "react";
 
 interface CreateTaskFormProps {
   onCancel?: () => void;
   projectOptions: { id: string; name: string; imageUrl: string }[];
+  currentProjet? : string
   memberOptions: { id: string; name: string }[];
 }
 
@@ -44,6 +46,7 @@ export const CreateTaskForm = ({
   onCancel,
   projectOptions,
   memberOptions,
+  currentProjet = undefined,
 }: CreateTaskFormProps) => {
   const workspaceId = useWorkspaceId();
   const { mutate, isPending } = useCreateTask();
@@ -51,7 +54,7 @@ export const CreateTaskForm = ({
   const form = useForm<z.infer<typeof createtaskSchema>>({
     resolver: zodResolver(createtaskSchema.omit({ workspaceId: true })),
     defaultValues: {
-      workspaceId,
+      workspaceId
     },
   });
 
@@ -66,6 +69,12 @@ export const CreateTaskForm = ({
       }
     );
   };
+
+  useEffect(() => {
+    if(currentProjet){
+      form.setValue("projectId", currentProjet);
+    }
+  }, [currentProjet])
 
   return (
     <Card className="w-full h-full border-none shadow-none">

--- a/src/features/tasks/components/create-task-modal.tsx
+++ b/src/features/tasks/components/create-task-modal.tsx
@@ -7,12 +7,12 @@ import { CreateTaskFormWrapper } from "./create-task-form-wrapper";
 import { useCreateTaskModal } from "../hooks/use-create-task-modal";
 
 export const CreateTaskModal = () => {
-    const { isOpen, setIsOpen, close } = useCreateTaskModal()
+    const { isOpen, setIsOpen, close , defaultProjet } = useCreateTaskModal()
 
     return (
         <ResponsiveModal open={isOpen} onopenchange={setIsOpen}>
             <div>
-                <CreateTaskFormWrapper onCancel={close} />
+                <CreateTaskFormWrapper onCancel={close} selectProjetId ={defaultProjet}/>
             </div>
         </ResponsiveModal>
     )

--- a/src/features/tasks/components/task-view-switcher.tsx
+++ b/src/features/tasks/components/task-view-switcher.tsx
@@ -95,7 +95,7 @@ export const TaskViewSwitcher = ({ hideProjectFilter }: TaskViewSwitcherProps) =
                         </TabsTrigger>
                     </TabsList>
                     <Button
-                        onClick={open}
+                        onClick={() => open(workspaceId ?? undefined)}
                         size="sm"
                         className="w-full lg:w-auto"
                     >

--- a/src/features/tasks/hooks/use-create-task-modal.ts
+++ b/src/features/tasks/hooks/use-create-task-modal.ts
@@ -1,4 +1,4 @@
-import { useQueryState, parseAsBoolean } from "nuqs"
+import { useQueryState, parseAsBoolean, parseAsString } from 'nuqs';
 
 export const useCreateTaskModal = () => {
     const [isOpen, setIsOpen] = useQueryState(
@@ -6,13 +6,29 @@ export const useCreateTaskModal = () => {
         parseAsBoolean.withDefault(false).withOptions({ clearOnDefault: true })
     )
 
-    const open = () => setIsOpen(true)
-    const close = () => setIsOpen(false)
+    const [defaultProjet, setDefaultProjet] = useQueryState(
+        "default-project",
+        parseAsString.withDefault("")
+    );
+
+
+    const open = (id : string | undefined) => {
+        setIsOpen(true)
+        if(id){
+            setDefaultProjet(id);
+        }
+    }
+    const close = () => {
+        setIsOpen(false)
+        setDefaultProjet("");
+    } 
 
     return {
         isOpen,
         open,
         close,
         setIsOpen,
+        defaultProjet,
+        setDefaultProjet,
     }
 }


### PR DESCRIPTION
Salut,

J’ai remarqué sur le site que lorsque le modal "Créer une nouvelle tâche" est ouvert dans un projet, celui-ci ne se sélectionne pas automatiquement. Cela pourrait améliorer l’expérience utilisateur en évitant une sélection manuelle à chaque fois.

Merci